### PR TITLE
Perf hack

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -237,7 +237,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     $this->composerLock,
                     $this->composerJson
                 );
-                $indexer->index()->otherwise('\\LanguageServer\\crash');
+                yield $indexer->index()->otherwise('\\LanguageServer\\crash');
             }
 
 

--- a/src/PhpDocumentLoader.php
+++ b/src/PhpDocumentLoader.php
@@ -19,7 +19,7 @@ class PhpDocumentLoader
      *
      * @var PhpDocument
      */
-    private $documents = [];
+    public $documents = [];
 
     /**
      * @var ContentRetriever

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -265,7 +265,15 @@ class TextDocument
     public function definition(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
         return coroutine(function () use ($textDocument, $position) {
-            $document = yield $this->documentLoader->getOrLoad($textDocument->uri);
+            $documentLoader = $this->documentLoader;//->getOrLoad($textDocument->uri);
+            $document = null;
+            if (isset($documentLoader->documents[$textDocument->uri])) {
+              $document = $documentLoader->documents[$textDocument->uri];
+            } else {
+              $document = yield $documentLoader->load($textDocument->uri);
+              $documentLoader->documents[$textDocument->uri] = $document; 
+            }
+
             $node = $document->getNodeAtPosition($position);
             if ($node === null) {
                 return [];


### PR DESCRIPTION
2 things changed essentially:

1. make the global indexing part synchronized instead of asynced. This will add a few seconds to the total time but frees us from the need to wait for `definition-added` event to complete.
2. avoid re-opening/re-loading a same document's content in definition queries. We could do better with memory usage, but I think at this moment it works for the purpose.