### PR TITLE
Support autoload.

### DIFF
--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -27,7 +27,13 @@ class DefinitionResolver
     private $prettyPrinter;
 
 
-		public $autoloadInfo;
+    public $autoloadInfo;
+
+    // The followings are autoloading properties.
+    public $autoloadLibraries;
+    public $autoloadClasses;
+    public $autoloadModels;
+    public $autoloadLanguages;
 
 
     /**

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -26,6 +26,10 @@ class DefinitionResolver
      */
     private $prettyPrinter;
 
+
+		public $autoloadInfo;
+
+
     /**
      * @param ReadableIndex $index
      */

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -117,6 +117,18 @@ class Indexer
             /** @var string[][] */
             $deps = [];
 
+            $ending = "application/config/autoload.php";
+            $endingLength = strlen($ending);
+            foreach ($uris as $uri) {
+              $found = (substr($uri, -$endingLength) === $ending);
+
+              // if found, put it to the beginning of the list so that it gets analyzed first.
+              if ($found) {
+                array_unshift($uris, $uri); 
+                break;
+              }
+            }
+
             foreach ($uris as $uri) {
                 $packageName = getPackageName($uri, $this->composerJson);
                 if ($this->composerLock !== null && $packageName) {

--- a/src/NodeVisitor/DynamicLoader.php
+++ b/src/NodeVisitor/DynamicLoader.php
@@ -35,6 +35,9 @@ class DynamicLoader extends NodeVisitorAbstract
       }
 
       $extends = $node->extends;
+      if (!isset($extends->parts)) {
+          return;
+      }
       $shouldAutoload = false;
       foreach ($extends->parts as $part) {
         // TODO: add more criteria here?

--- a/src/NodeVisitor/DynamicLoader.php
+++ b/src/NodeVisitor/DynamicLoader.php
@@ -62,7 +62,7 @@ class DynamicLoader extends NodeVisitorAbstract
       }
 
       // check left hand side.
-      $lhs = $this->var;
+      $lhs = $node->var;
       if (!($lhs instanceof Node\Expr\ArrayDimFetch)) {
         return;
       }
@@ -72,7 +72,7 @@ class DynamicLoader extends NodeVisitorAbstract
         return;
       }
 
-      if ($dimFetchVar !== "autoload") {
+      if ($dimFetchVar->name !== "autoload") {
         return;
       }
       // end of checking left hand side.
@@ -85,7 +85,7 @@ class DynamicLoader extends NodeVisitorAbstract
       $target = $dim->value;
 
       // extract right hand side.
-      $rhs = $this->expr;
+      $rhs = $node->expr;
       if (!($rhs instanceof Node\Expr\Array_)) {
         return;
       }

--- a/src/NodeVisitor/DynamicLoader.php
+++ b/src/NodeVisitor/DynamicLoader.php
@@ -52,17 +52,35 @@ class DynamicLoader extends NodeVisitorAbstract
         return;
       }
 
-      // TODO: implement other components.
-      foreach ($this->definitionResolver->autoloadLibraries as $key => $value) {
-        //TODO: create field using $key (String) and $value (Node)
-        $this->createAutoloadDefinition($node, $value);
+      if (isset($this->definitionResolver->autoloadLibraries)) {
+        foreach ($this->definitionResolver->autoloadLibraries as $key => $value) {
+          $this->createAutoloadDefinition($node, $value);
+        }
       }
 
-      foreach ($this->definitionResolver->autoloadModels as $key => $value) {
-        //TODO: create field using $key (String) and $value (Node)
-        $this->createAutoloadDefinition($node, $value);
+      if (isset($this->definitionResolver->autoloadModels)) {
+        foreach ($this->definitionResolver->autoloadModels as $key => $value) {
+          $this->createAutoloadDefinition($node, $value);
+        }
       }
 
+      if (isset($this->definitionResolver->autoloadHelpers)) {
+        foreach ($this->definitionResolver->autoloadHelpers as $key => $value) {
+          $this->createAutoloadDefinition($node, $value);
+        }
+      }
+
+      if (isset($this->definitionResolver->autoloadConfig)) {
+        foreach ($this->definitionResolver->autoloadConfig as $key => $value) {
+          $this->createAutoloadDefinition($node, $value);
+        }
+      }
+
+      if (isset($this->definitionResolver->autoloadLanguage)) {
+        foreach ($this->definitionResolver->autoloadLanguage as $key => $value) {
+          $this->createAutoloadDefinition($node, $value);
+        }
+      }
     }
 
     public function visitAutoloadNode(Node $node) {
@@ -138,7 +156,7 @@ class DynamicLoader extends NodeVisitorAbstract
 
         // The follwoing is for handling dynamic loading. (Finished)
 
-        // check its name is 'model'
+        // check its name is 'model', 'library' or 'helper'.
         if (!($node instanceof Node\Expr\MethodCall)) {
             return;
         }


### PR DESCRIPTION
PHP analysis on autoloading is supported in this patch.

At this moment we assume that the autoloading classes do not derive other parent classes; we also assume that the classes that auto-loads are subclasses of `CI_Controller`, `ST_Auth_Controller` or `ST_Controller`.